### PR TITLE
支持页面json配置相对路径跳转

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,6 +104,9 @@ export function activate(context: vscode.ExtensionContext) {
             compPath = config.usingComponents[tag];
           }
 
+          // 获取当前json的path
+          let prePath = path.parse(jsonFile).dir
+
           // 页面或者组件没有定义，查找一下全局配置
           if (!compPath) {
             jsonFile = path.join(rootPath, appFile);
@@ -112,9 +115,12 @@ export function activate(context: vscode.ExtensionContext) {
             if (config.usingComponents && config.usingComponents[tag]) {
               compPath = config.usingComponents[tag];
             }
+
+            // 使用项目根path
+            prePath = rootPath
           }
 
-          const componentPath = path.join(rootPath, `${compPath}.js`);
+          const componentPath = path.join(prePath, `${compPath}.js`);
 
           return new vscode.Location(
             vscode.Uri.file(componentPath),


### PR DESCRIPTION
上一版本问题：统一使用rootPath作为path.join的第一个参数，会导致页面usingComponents使用相对路径时 得到的componentPath错误。

增加逻辑：根据json源设置prePath，json为页面则prePath为json所在文件夹，json为app则prePath为rootPath

自测OK